### PR TITLE
Fix: align real image and label transforms in DiffSynth (3D)

### DIFF
--- a/scripts/train_gaussian_vary_vary_bias.py
+++ b/scripts/train_gaussian_vary_vary_bias.py
@@ -304,7 +304,7 @@ class SharedSynth(torch.nn.Module):
 
 
 class DiffSynth(torch.nn.Module):
-    """Apply different geometric transform for synth and real"""
+    """Apply different geometric transforms for synth and real, preserving intra-domain alignment"""
 
     def __init__(self, synth):
         super().__init__()
@@ -314,12 +314,19 @@ class DiffSynth(torch.nn.Module):
         # slab: labels of the source (synth) domain
         # img: image of the target (real) domain
         # lab: label of the target (real) domain
-        final = self.synth.make_final(slab, 1)
-        final.deform = final.deform.make_final(slab)
-        simg, slab = final(slab)
-        rimg, rlab = final.deform(img, lab)
-        rimg = final.intensity(img)
-        rlab = final.postproc(rlab)
+
+        # Synthetic: sample transform specific to slab
+        final_synth = self.synth.make_final(slab, 1)
+        final_synth.deform = final_synth.deform.make_final(slab)
+        simg, slab = final_synth(slab)
+
+        # Real: sample a separate transform specific to img/lab (but shared between them)
+        final_real = self.synth.make_final(img, 1)
+        final_real.deform = final_real.deform.make_final(img)
+        rimg, rlab = final_real.deform([img, lab])  # ensure same deformation applied
+        rimg = final_real.intensity(rimg)
+        rlab = final_real.postproc(rlab)
+
         return simg, slab, rimg, rlab
 
 

--- a/scripts/train_noise.py
+++ b/scripts/train_noise.py
@@ -269,7 +269,7 @@ class SharedSynth(torch.nn.Module):
 
 
 class DiffSynth(torch.nn.Module):
-    """Apply different geometric transform for synth and real"""
+    """Apply different geometric transforms for synth and real, preserving intra-domain alignment"""
 
     def __init__(self, synth):
         super().__init__()
@@ -279,12 +279,19 @@ class DiffSynth(torch.nn.Module):
         # slab: labels of the source (synth) domain
         # img: image of the target (real) domain
         # lab: label of the target (real) domain
-        final = self.synth.make_final(slab, 1)
-        final.deform = final.deform.make_final(slab)
-        simg, slab = final(slab)
-        rimg, rlab = final.deform(img, lab)
-        rimg = final.intensity(img)
-        rlab = final.postproc(rlab)
+
+        # Synthetic: sample transform specific to slab
+        final_synth = self.synth.make_final(slab, 1)
+        final_synth.deform = final_synth.deform.make_final(slab)
+        simg, slab = final_synth(slab)
+
+        # Real: sample a separate transform specific to img/lab (but shared between them)
+        final_real = self.synth.make_final(img, 1)
+        final_real.deform = final_real.deform.make_final(img)
+        rimg, rlab = final_real.deform([img, lab])  # ensure same deformation applied
+        rimg = final_real.intensity(rimg)
+        rlab = final_real.postproc(rlab)
+
         return simg, slab, rimg, rlab
 
 

--- a/scripts/train_noise_bias.py
+++ b/scripts/train_noise_bias.py
@@ -304,7 +304,7 @@ class SharedSynth(torch.nn.Module):
 
 
 class DiffSynth(torch.nn.Module):
-    """Apply different geometric transform for synth and real"""
+    """Apply different geometric transforms for synth and real, preserving intra-domain alignment"""
 
     def __init__(self, synth):
         super().__init__()
@@ -314,12 +314,19 @@ class DiffSynth(torch.nn.Module):
         # slab: labels of the source (synth) domain
         # img: image of the target (real) domain
         # lab: label of the target (real) domain
-        final = self.synth.make_final(slab, 1)
-        final.deform = final.deform.make_final(slab)
-        simg, slab = final(slab)
-        rimg, rlab = final.deform(img, lab)
-        rimg = final.intensity(img)
-        rlab = final.postproc(rlab)
+
+        # Synthetic: sample transform specific to slab
+        final_synth = self.synth.make_final(slab, 1)
+        final_synth.deform = final_synth.deform.make_final(slab)
+        simg, slab = final_synth(slab)
+
+        # Real: sample a separate transform specific to img/lab (but shared between them)
+        final_real = self.synth.make_final(img, 1)
+        final_real.deform = final_real.deform.make_final(img)
+        rimg, rlab = final_real.deform([img, lab])  # ensure same deformation applied
+        rimg = final_real.intensity(rimg)
+        rlab = final_real.postproc(rlab)
+
         return simg, slab, rimg, rlab
 
 

--- a/scripts/train_noise_bias_weight_no_empty.py
+++ b/scripts/train_noise_bias_weight_no_empty.py
@@ -303,7 +303,7 @@ class SharedSynth(torch.nn.Module):
 
 
 class DiffSynth(torch.nn.Module):
-    """Apply different geometric transform for synth and real"""
+    """Apply different geometric transforms for synth and real, preserving intra-domain alignment"""
 
     def __init__(self, synth):
         super().__init__()
@@ -313,12 +313,19 @@ class DiffSynth(torch.nn.Module):
         # slab: labels of the source (synth) domain
         # img: image of the target (real) domain
         # lab: label of the target (real) domain
-        final = self.synth.make_final(slab, 1)
-        final.deform = final.deform.make_final(slab)
-        simg, slab = final(slab)
-        rimg, rlab = final.deform(img, lab)
-        rimg = final.intensity(img)
-        rlab = final.postproc(rlab)
+
+        # Synthetic: sample transform specific to slab
+        final_synth = self.synth.make_final(slab, 1)
+        final_synth.deform = final_synth.deform.make_final(slab)
+        simg, slab = final_synth(slab)
+
+        # Real: sample a separate transform specific to img/lab (but shared between them)
+        final_real = self.synth.make_final(img, 1)
+        final_real.deform = final_real.deform.make_final(img)
+        rimg, rlab = final_real.deform([img, lab])  # ensure same deformation applied
+        rimg = final_real.intensity(rimg)
+        rlab = final_real.postproc(rlab)
+
         return simg, slab, rimg, rlab
 
 


### PR DESCRIPTION
This PR fixes a bug in `DiffSynth` where the real image and label were incorrectly deformed using a transformation sampled from the synthetic domain (`slab`). This caused **misalignment in the real image-label pair**, especially in 3D experiments.

Changes:
- Sample a dedicated transform pipeline (`make_final`) for the real data using `img`.
- Pass `[img, lab]` to `.deform()` to apply **the same geometric transform** to both.